### PR TITLE
Speed and scalability improvements for graph multiresolution

### DIFF
--- a/doc/reference/utils.rst
+++ b/doc/reference/utils.rst
@@ -27,3 +27,13 @@ Distanz
 Resistance distance
 -------------------
 .. autofunction:: pygsp.utils.resistance_distance
+
+.. autofunction:: pygsp.utils.approx_resistance_distance
+
+SDD optimized sparse linear system solver
+-----------------------------------------
+.. autofunction:: pygsp.utils.splu_inv_dot
+
+Sparse matrix block extraction
+------------------------------
+.. autofunction:: pygsp.utils.extract_submatrix

--- a/pygsp/graphs/graph.py
+++ b/pygsp/graphs/graph.py
@@ -576,6 +576,30 @@ class Graph(object):
 
         self.L = L
 
+    def create_incidence_matrix(self):
+        r"""
+        Compute a new incidence matrix B and associated edge weight matrix We
+
+        The combinatorial graph laplacian can be recovered with L = B.T W B
+        """
+        if not hasattr(self, 'directed'):
+            self.is_directed()
+
+        if self.directed or not self.connected:
+            raise NotImplementedError('Focusing on connected non directed graphs first.')
+
+        start_nodes, end_nodes, weights = sparse.find(sparse.tril(self.W))
+
+        data = np.concatenate([np.ones(self.Ne/2), -np.ones(self.Ne/2)])
+        row = np.concatenate([np.arange(self.Ne/2), np.arange(self.Ne/2)])
+        col = np.concatenate([start_nodes, end_nodes])
+
+        self.B = sparse.coo_matrix((data, (row, col)),
+                                   shape=(self.Ne/2, self.N) ).tocsc()
+        self.Wb = sparse.diags(weights,0)
+        self.start_nodes = start_nodes
+        self.end_nodes = end_nodes
+
     def estimate_lmax(self, force_recompute=False):
         r"""
         Estimate the maximal eigenvalue.

--- a/pygsp/graphs/graph.py
+++ b/pygsp/graphs/graph.py
@@ -578,9 +578,11 @@ class Graph(object):
 
     def create_incidence_matrix(self):
         r"""
-        Compute a new incidence matrix B and associated edge weight matrix We
+        Compute a new incidence matrix B and associated edge weight matrix Wb.
 
-        The combinatorial graph laplacian can be recovered with L = B.T W B
+        The combinatorial graph laplacian can be recovered with L = B.T Wb B
+        For convenience, the heads and tails of each edge are saved in two
+        additional attributes start_nodes and end_nodes.
         """
         if not hasattr(self, 'directed'):
             self.is_directed()

--- a/pygsp/utils.py
+++ b/pygsp/utils.py
@@ -184,8 +184,39 @@ def resistance_distance(M):  # 1 call dans operators.reduction
     return rd
 
 def approx_resistance_distance(g, epsilon):
-    """
-    Computes the resistance distance using the ST algorithm
+    r"""
+    Compute the resistance distances of each edge of a graph using the
+    Spielman-Srivastava algorithm.
+
+    Parameters
+    ----------
+    g : Graph
+        Graph structure
+
+    epsilon: float
+        Sparsification parameter
+
+    Returns
+    -------
+    rd : ndarray
+        distance for every edge in the graph
+
+    Examples
+    --------
+    >>>
+    >>>
+    >>>
+
+    Notes
+    -----
+    This implementation avoids the blunt matrix inversion of the exact distance
+    distance and can scale to very large graphs. The approximation error is
+    included in the budget of Spielman-Srivastava sparsification algorithm.
+
+    References
+    ----------
+    :cite:`klein1993resistance` :cite:`spielman2011graph`
+
     """
     g.create_incidence_matrix()
     n = g.N
@@ -199,7 +230,7 @@ def approx_resistance_distance(g, epsilon):
 
 def extract_submatrix(M, ind_rows, ind_cols):
     r"""
-    Extract a bloc from the provided sparse matrix
+    Extract a bloc of specific rows and columns from a sparse matrix.
 
     Parameters
     ----------
@@ -219,6 +250,14 @@ def extract_submatrix(M, ind_rows, ind_cols):
     sub_M: sparse matrix
         Submatrix obtained from M keeping only the requested rows and columns
 
+    Examples
+    --------
+    >>> # Extracting first diagonal block from a sparse matrix
+    >>> M = sparse.csc_matrix((16, 16))
+    >>> ind_row = range(8); ind_col = range(8)
+    >>> block = extract_submatrix(M, ind_row, ind_col)
+    >>> block.shape
+    (8, 8)
     """
     M = M.tocoo()
 
@@ -238,10 +277,33 @@ def extract_submatrix(M, ind_rows, ind_cols):
 
 def splu_inv_dot(A, B, threshold=np.spacing(1)):
     """
-    Compute A^{-1}B for sparse matrices A and B, assuming A is SDD,
-    using superLU
+    Compute A^{-1}B for sparse matrix A assuming A is Symmetric Diagonally
+    Dominant (SDD).
+
+    Parameters
+    ----------
+    A : sparse matrix
+        Input SDD matrix to invert, in CSC or CSR form.
+
+    B : sparse matrix
+        Matrix or vector of the right hand side
+
+    threshold: float, optional
+        Threshold to apply to result as to remove numerical noise before
+        conversion to sparse format. (default: machine precision)
+
+    Returns
+    -------
+    res: sparse matrix
+        Result of A^{-1}B
+
+    Notes
+    -----
+    This inversion by sparse linear system solving is optimized for SDD matrices
+    such as Graph Laplacians. Note that B is converted to a dense matrix before
+    being sent to splu, which is more computationally efficient but can lead to
+    very large memory usage if B is large.
     """
-    s = A.shape
     # Compute the LU decomposition of A
     lu = sparse.linalg.splu(A,
                         diag_pivot_thresh=A.diagonal().min()*0.5,

--- a/pygsp/utils.py
+++ b/pygsp/utils.py
@@ -182,3 +182,78 @@ def resistance_distance(M):  # 1 call dans operators.reduction
         - pseudo - pseudo.T
 
     return rd
+
+def approx_resistance_distance(g, epsilon):
+    """
+    Computes the resistance distance using the ST algorithm
+    """
+    g.create_incidence_matrix()
+    n = g.N
+    k = 24 * np.log( n / epsilon)
+    Q = ((np.random.rand(int(k),g.Wb.shape[0]) > 0.5)*2. -1)/np.sqrt(k)
+    Y = sparse.csc_matrix(Q).dot(np.sqrt(g.Wb).dot(g.B))
+
+    r = splu_inv_dot(g.L, Y.T)
+
+    return ((r[g.start_nodes] - r[g.end_nodes]).toarray()**2).sum(axis=1)
+
+def extract_submatrix(M, ind_rows, ind_cols):
+    r"""
+    Extract a bloc from the provided sparse matrix
+
+    Parameters
+    ----------
+
+    M : sparse matrix
+        Input matrix
+
+    ind_rows: ndarray
+        Indices of rows to extract
+
+    ind_cols: ndarray
+        Indices of columns to extract
+
+    Returns
+    -------
+
+    sub_M: sparse matrix
+        Submatrix obtained from M keeping only the requested rows and columns
+
+    """
+    M = M.tocoo()
+
+    # Finding elements of the sub-matrix
+    m = np.in1d(M.row, ind_rows) & np.in1d(M.col, ind_cols)
+    n_elem = m.sum()
+
+    # Finding new rows and column indices
+    # The concatenation with ind and ind_comp is there to account for the fact that some rows
+    # or columns may not have elements in them, which foils this np.unique trick
+    _, row = np.unique(np.concatenate([M.row[m], ind_rows]), return_inverse=True)
+    _, col = np.unique(np.concatenate([M.col[m], ind_cols]), return_inverse=True)
+
+    return sparse.coo_matrix((M.data[m], (row[:n_elem],col[:n_elem])),
+                         shape=(len(ind_rows),len(ind_cols)),copy=True)
+
+
+def splu_inv_dot(A, B, threshold=np.spacing(1)):
+    """
+    Compute A^{-1}B for sparse matrices A and B, assuming A is SDD,
+    using superLU
+    """
+    s = A.shape
+    # Compute the LU decomposition of A
+    lu = sparse.linalg.splu(A,
+                        diag_pivot_thresh=A.diagonal().min()*0.5,
+                        permc_spec='MMD_AT_PLUS_A',
+                        options={'SymmetricMode':True})
+
+    res = lu.solve(B.toarray())
+
+    # Threshold the result to remove numerical noise
+    res[abs(res) < threshold] = 0
+
+    # Convert to sparse matrix
+    res = sparse.csc_matrix(res)
+
+    return res


### PR DESCRIPTION
The motivation for these modification is to improve the scalability of the code to be able to handle much larger graphs.

With the baseline code, I couldn't compute graph pyramids for graphs with about 40,000 nodes, the peak memory consumption went above 500GB ! Turns out this was due to 2 main problems:

  - In the `kron_reduction` function, the computation of the Schur complement was actually turning back the sparse input matrices into dense matrices. Plus, the computation of the Schur complement can be sped up by using a linear equation solver optimized to handle SDD matrices (symmetric diagonally dominant), which is the case of graph laplacians. There are even more efficient algorithms out there (starting with Cholesky decomposition) such as Koutis et al. (2011) arXiv:1102.4842 but I didn't find an out of the box python implementation and SuperLU seemed to do the job for me. I ended up rewriting bits of  `kron_reduction` to ensure that the sparse matrices were not turned into dense matrices when not necessary, and I added `pygsp.utils.splu_inv_dot` as an optimized alternative to the use of `scipy.sparse.spsolve` .

  - In the `graph_sparsify` function, the computation of the resistance distances was done using blunt matrix inversion in `pygsp.utils.resistance_distance` which tries to invert it a potentially very large Laplacian matrix. After a kron reduction, this laplacian can have a lot of non zero elements, that's what was causing the worse of the memory consumption in my case. However, it turns out that the whole point of the Spielman-Srivastava spectral sparsification algorithm is to avoid having to compute this inverse, the algorithm only requires approximate distances and provides a procedure to compute them. I implemented `pygsp.utils.approx_resistance_distance` to compute these distances based on the algorithm described in arxiv:0803.0929 . It still requires a way of solving a linear inverse system, where I used again my customized `pygsp.utils.splu_inv_dot` but it should be noted that there are much faster ways of doing this. Including the near linear time algorithm described in arXiv:1209.5821v3 

With these modifications, I can now compute graph multiresolutions in practice for graphs with about 50,000 nodes and 1e6 edges without running into memory issues on a standard desktop. The slowest point in the process is the sampling time for the edges in  `graph_sparsify`, `scipy.stats.rv_discrete` takes about 1s to sample 10,000 deviates, in my case the algorithm needed 16e6 which takes about 30min just to sample random numbers whereas the rest of the algorithm only takes minutes, so it's really stupid, but at least it eventually works.

I tried to comment and document these modifications in the hope that they might be useful to others, everything seems to work for me but someone should take a close look to check that it doesn't break anything.