### PR TITLE
Fix extract_components

### DIFF
--- a/pygsp/graphs/graph.py
+++ b/pygsp/graphs/graph.py
@@ -451,7 +451,8 @@ class Graph(fourier.GraphFourier, difference.GraphDifference):
         # indices = [] # Assigned but never used
 
         while not visited.all():
-            stack = set(np.nonzero(~visited)[0])
+            # pick a node not visted yet
+            stack = set(np.nonzero(~visited)[0][[0]])
             comp = []
 
             while len(stack):


### PR DESCRIPTION
Current `extract_components` have a bug.
It may return the whole graph in any non-connected graphs since `stack` is initialized all indices of nodes.