### PR TITLE
fix test broken by NetworkX update

### DIFF
--- a/pygsp/tests/test_graphs.py
+++ b/pygsp/tests/test_graphs.py
@@ -721,8 +721,8 @@ class TestImportExport(unittest.TestCase):
         graph.set_signal(signal2, "signal2")
         graph_nx = graph.to_networkx()
         for i in range(graph.N):
-            self.assertEqual(graph_nx.node[i]["signal1"], signal1[i])
-            self.assertEqual(graph_nx.node[i]["signal2"], signal2[i])
+            self.assertEqual(graph_nx.nodes[i]["signal1"], signal1[i])
+            self.assertEqual(graph_nx.nodes[i]["signal2"], signal2[i])
         # invalid signal type
         graph = graphs.Path(3)
         graph.set_signal(np.array(['a', 'b', 'c']), 'sig')


### PR DESCRIPTION
networkx 2.4 [removed](https://github.com/networkx/networkx/commit/6b1ce03f485076d39994e8d624bbf6ca82466eb9) `graph.node` in favor of `graph.nodes`