### PR TITLE
doc gallery: save images as SVG (instead of PNG)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import pygsp
+from sphinx_gallery.scrapers import matplotlib_scraper
 
 extensions = [
     'sphinx.ext.viewcode',
@@ -41,6 +42,14 @@ import numpy as np
 from pygsp import graphs, filters, utils, plotting
 """
 
+class matplotlib_svg_scraper(object):
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+    def __call__(self, *args, **kwargs):
+        return matplotlib_scraper(*args, format='svg', **kwargs)
+
 extensions.append('sphinx_gallery.gen_gallery')
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
@@ -50,6 +59,7 @@ sphinx_gallery_conf = {
     'backreferences_dir': 'backrefs',
     'doc_module': 'pygsp',
     'show_memory': True,
+    'image_scrapers': matplotlib_svg_scraper(),
 }
 
 exclude_patterns = ['_build']


### PR DESCRIPTION
Some code I had around. I'm not sure we want this. IIRC, the main issue was that SVGs can be quite big if there are many objects (e.g., vertices), in a plot.